### PR TITLE
Remove Space in Template to Assist Team

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 **Addressed Issue(s)**
 
-closes # 
+closes #
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
Removed Space in Template.
The team is having a hard time with github using issue references.
I think part of that is an extra space in the template.